### PR TITLE
Launch emacs with --init-directory pointing to empty path in store

### DIFF
--- a/packages/emacs.nix
+++ b/packages/emacs.nix
@@ -1,47 +1,54 @@
-{ pkgs, lib, ... }:
-
-let
+pkgs: let
+  lib = pkgs.lib;
   myEmacsConfig = ./emacs;
   emacsConfigs = lib.mapAttrsToList (fname: _: "${myEmacsConfig}/${fname}") (
     lib.filterAttrs (_: type: type == "regular") (builtins.readDir "${myEmacsConfig}/")
   );
-  
-in
-pkgs.emacsWithPackagesFromUsePackage {
-  package = pkgs.emacs-nox;
-  config = lib.concatMapStringsSep "\n" builtins.readFile emacsConfigs;
-  # defaultInitFile = true;
-  # alwaysEnsure = true;
-  override = epkgs: epkgs // {
-    my-config = (pkgs.runCommand "default.el" {} ''
-              mkdir -p $out/share/emacs/site-lisp
-              cp -r ${myEmacsConfig}/* $out/share/emacs/site-lisp/
-            '');
+  emacsPkg = pkgs.emacsWithPackagesFromUsePackage {
+    package = pkgs.emacs-nox;
+    config = lib.concatMapStringsSep "\n" builtins.readFile emacsConfigs;
+    # defaultInitFile = true;
+    # alwaysEnsure = true;
+    override = epkgs: epkgs // {
+      my-config = (pkgs.runCommand "default.el" {} ''
+                mkdir -p $out/share/emacs/site-lisp
+                cp -r ${myEmacsConfig}/* $out/share/emacs/site-lisp/
+              '');
+    };
+    extraEmacsPackages = epkgs: [
+      epkgs.llama
+      epkgs.f
+      epkgs.s
+      epkgs.ht
+      epkgs.lv
+      epkgs.spinner
+      # epkgs.use-package
+      epkgs.my-config
+      # epkgs.magit
+      # epkgs.nix-mode
+      # epkgs.flycheck
+      # epkgs.json-mode
+      # epkgs.python-mode
+      # epkgs.autothemer
+      # epkgs.lsp-mode
+      # epkgs.lsp-pyright
+      # epkgs.all-the-icons-dired
+      # epkgs.all-the-icons
+      pkgs.basedpyright
+      pkgs.nodePackages.vscode-json-languageserver
+      pkgs.nixd
+      pkgs.intelephense
+      pkgs.emacs-all-the-icons-fonts
+      pkgs.hack-font
+    ];
   };
-  extraEmacsPackages = epkgs: [
-    epkgs.llama
-    epkgs.f
-    epkgs.s
-    epkgs.ht
-    epkgs.lv
-    epkgs.spinner
-    # epkgs.use-package
-    epkgs.my-config
-    # epkgs.magit
-    # epkgs.nix-mode
-    # epkgs.flycheck
-    # epkgs.json-mode
-    # epkgs.python-mode
-    # epkgs.autothemer
-    # epkgs.lsp-mode
-    # epkgs.lsp-pyright
-    # epkgs.all-the-icons-dired
-    # epkgs.all-the-icons
-    pkgs.basedpyright
-    pkgs.nodePackages.vscode-json-languageserver
-    pkgs.nixd
-    pkgs.intelephense
-    pkgs.emacs-all-the-icons-fonts
-    pkgs.hack-font
-  ];
+in
+pkgs.symlinkJoin {
+  name = "emacs";
+  paths = [ emacsPkg ];
+  buildInputs = with pkgs; [ makeWrapper ];
+  postBuild = ''
+    mkdir $out/emptyConfig
+    wrapProgram $out/bin/emacs --add-flags "--init-directory=$out/emptyConfig"
+  '';
 }


### PR DESCRIPTION
Use symlinkJoin to add flags to emacs so it isn't impacted by default config directories.